### PR TITLE
Add name patch for OSX sierra et seq...

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -120,6 +120,10 @@ TCL_SRC_DIR	= @TCL_SRC_DIR@
 # Not used, but retained for reference of what libs Tcl required
 #TCL_LIBS	= @TCL_LIBS@
 
+# For Sierra and beyond you need to patch the install path into the binary. See "patch_name" target, below
+PATCH_NAME      = @PATCH_NAME@
+INSTALL_NAME    = $(pkglibdir)/$(PKG_LIB_FILE)
+
 #========================================================================
 # TCLLIBPATH seeds the auto_path in Tcl's init.tcl so we can test our
 # package without installing.  The other environment variables allow us
@@ -193,7 +197,12 @@ all: binaries libraries doc
 # of the Makefile, in the "BINARIES" variable.
 #========================================================================
 
-binaries: $(BINARIES)
+binaries: $(BINARIES) $(PATCH_NAME)
+
+# If defined, this target will trigger after the library is made
+patch_name:
+	install_name_tool -id $(INSTALL_NAME) $(PKG_LIB_FILE)
+#
 
 libraries:
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -7,3 +7,5 @@ builtin(include,tclconfig/tcl.m4)
 #
 # Add here whatever m4 macros you want to define for your package
 #
+    AC_SUBST(PATCH_NAME)
+

--- a/configure.in
+++ b/configure.in
@@ -191,6 +191,15 @@ TEA_MAKE_LIB
 TEA_PROG_TCLSH
 #TEA_PROG_WISH
 
+#
+# If we're on OSX define PATCH_NAME so it's got a Makefile target name
+#
+    case $system in
+	Darwin-*)
+	    PATCH_NAME="patch_name";;
+    esac
+
+
 #--------------------------------------------------------------------
 # Finally, substitute all of the various values into the Makefile.
 # You may alternatively have a special pkgIndex.tcl.in or other files


### PR DESCRIPTION
OS X sierra needs full path in "name" for library. Which is like something from RSX-11, but it is what it is.