### PR TITLE
Improved interact

### DIFF
--- a/casstcl.tcl
+++ b/casstcl.tcl
@@ -336,7 +336,10 @@ proc interact {cassHandle} {
 					continue
 				}
 				schema {
-					puts_schema {*}$builtin_args
+					if {[catch {puts_schema {*}$builtin_args} catchResult]} {
+						puts $catchResult
+						puts "$::errorCode"
+					}
 					continue
 				}
 				exit {


### PR DESCRIPTION
Add builtin commands to query cassandra meta-information in tcqlsh.

Commands: cluster_version, keyspaces, tables, columns, columns_with_types, schema, help, exit

Schema does not look up primary/secondary keys etc, just dumps columns and types.