### PR TITLE
Nxt 723 - add duration type to casstcl

### DIFF
--- a/README.Linux
+++ b/README.Linux
@@ -1,0 +1,6 @@
+
+autoreconf
+./configure --mandir=/usr/share/man "$@"
+
+# Add "--enable-symbols" if you want debugging.
+

--- a/casstcl.tcl
+++ b/casstcl.tcl
@@ -29,6 +29,7 @@ namespace eval ::casstcl {
 		"org.apache.cassandra.db.marshal.TimeType"          time      \
 		"org.apache.cassandra.db.marshal.DateType"          timestamp \
 		"org.apache.cassandra.db.marshal.TimestampType"     timestamp \
+		"org.apache.cassandra.db.marshal.DurationType"      duration  \
 		"org.apache.cassandra.db.marshal.TimeUUIDType"      timeuuid  \
 		"org.apache.cassandra.db.marshal.UUIDType"          uuid      \
 		"org.apache.cassandra.db.marshal.IntegerType"       varint    \

--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([casstcl], [2.13.2])
+AC_INIT([casstcl], [2.14.0])
 
 #-----
 # Version with patch stripped

--- a/generic/casstcl_types.c
+++ b/generic/casstcl_types.c
@@ -2075,8 +2075,8 @@ casstcl_GetDurationFromObj(
   char c;
   
   // TODO parse ISO8601 formats
-  while(c = *string++) {
-    switch c {
+  while((c = *string++)) {
+    switch (c) {
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
 	value = value * 10 + *string - '0';
@@ -2090,13 +2090,13 @@ casstcl_GetDurationFromObj(
       // mo (months), ms (milliseconds), or m (minutes)
       case 'm': {
 	switch (*string) {
-	  'o': {
+	  case 'o': {
 	    months = months + value;
 	    value = 0;
 	    string++;
 	    break;
 	  }
-	  's': {
+	  case 's': {
 	    nanos = nanos + 1000000ull * value;
 	    value = 0;
 	    string++;
@@ -2154,7 +2154,7 @@ casstcl_GetDurationFromObj(
       default: {
 badparse:
 	Tcl_ResetResult(interp);
-	Tcl_AppendResult(interp, "badly formatted duration", msg, NULL);
+	Tcl_AppendResult(interp, "badly formatted duration '", Tcl_GetString(objPtr), "'.", NULL);
 	return TCL_ERROR;
       }
     }

--- a/generic/casstcl_types.c
+++ b/generic/casstcl_types.c
@@ -189,6 +189,10 @@ casstcl_cass_value_type_to_string (CassValueType valueType) {
       return "tuple";
     }
 
+    case CASS_VALUE_TYPE_DURATION: {
+      return "duration";
+    }
+
     default:
       return "unknown";
   }
@@ -238,6 +242,7 @@ casstcl_string_to_cass_value_type (char *string) {
       if (strcmp (string, "date") == 0) return CASS_VALUE_TYPE_DATE;
       if (strcmp (string, "decimal") == 0) return CASS_VALUE_TYPE_DECIMAL;
       if (strcmp (string, "double") == 0) return CASS_VALUE_TYPE_DOUBLE;
+      if (strcmp (string, "duration") == 0) return CASS_VALUE_TYPE_DURATION;
       break;
     }
 
@@ -647,6 +652,26 @@ int casstcl_cass_value_to_tcl_obj (casstcl_sessionClientData *ct, const CassValu
       }
 
       *tclObj = casstcl_NewTimestampObj (cassInt);
+      return TCL_OK;
+    }
+
+    case CASS_VALUE_TYPE_DURATION: {
+	cass_int32_t months;
+	cass_int32_t days;
+	cass_int64_t nanos;
+	CassError cassError;
+      Tcl_Obj *listObjv[3];
+
+	CassError = cass_value_get_duration (cassValue, &months, &days, &nanos);
+
+      if (cassError != CASS_OK) {
+        return casstcl_cass_error_to_tcl (ct, cassError);
+      }
+
+      listObjv[0] = Tcl_NewIntObj(months);
+      listObjv[1] = Tcl_NewintObj(days);
+      *tclObjv[2] = Tcl_NewWideIntObj (nanos);
+      *tclObj = Tcl_NewListObj(3, listObjv);
       return TCL_OK;
     }
 
@@ -1641,6 +1666,47 @@ int casstcl_bind_tcl_obj (casstcl_sessionClientData *ct, CassStatement *statemen
       }
       break;
     }
+
+    case CASS_VALUE_TYPE_DURATION: {
+      int listObjc;
+      Tcl_Obj **listObjv;
+	cass_int32_t months;
+	cass_int32_t days;
+	cass_int64_t nanos;
+
+      if (Tcl_ListObjGetElements (interp, obj, &listObjc, &listObjv) == TCL_ERROR) {
+        Tcl_AppendResult (interp, " while getting duration elements", NULL);
+        return TCL_ERROR;
+      }
+
+      if (listObjc != 3) {
+        Tcl_ResetResult(interp);
+        Tcl_AppendResult(interp, "duration requires exactly three elements", NULL);
+        return TCL_ERROR;
+      }
+
+      if (Tcl_GetIntFromObj(interp, listObjv[0], &months) != TCL_OK) {
+        Tcl_AppendResult (interp, " while extracting months", NULL);
+        return TCL_ERROR;
+      }
+
+      if (Tcl_GetIntFromObj(interp, listObjv[1], &days) != TCL_OK) {
+        Tcl_AppendResult (interp, " while extracting days", NULL);
+        return TCL_ERROR;
+      }
+      if (Tcl_GetWideIntFromObj(interp, listObjv[2], &nanos) != TCL_OK) {
+        Tcl_AppendResult (interp, " while extracting nanos", NULL);
+        return TCL_ERROR;
+      }
+
+      if (name == NULL) {
+        cassError = cass_statement_bind_duration(statement, index, months, days, nanos);
+      } else {
+        cassError = cass_statement_bind_duration_by_name (statement, name, months, days, nanos);
+      }
+      break;
+    }
+
 
     case CASS_VALUE_TYPE_BIGINT:
     case CASS_VALUE_TYPE_COUNTER: {

--- a/generic/casstcl_types.c
+++ b/generic/casstcl_types.c
@@ -2110,6 +2110,11 @@ casstcl_GetDurationFromObj(
 	}
 	break;
       }
+      case 'd': {
+	days = days + value;
+	value = 0;
+	break;
+      }
       case 'w': {
 	days = days + 7 * value;
 	value = 0;
@@ -2154,7 +2159,7 @@ casstcl_GetDurationFromObj(
       default: {
 badparse:
 	Tcl_ResetResult(interp);
-	Tcl_AppendResult(interp, "badly formatted duration '", Tcl_GetString(objPtr), "'.", NULL);
+	Tcl_AppendResult(interp, "badly formatted duration '", Tcl_GetString(objPtr), "' at '", --string, "'.", NULL);
 	return TCL_ERROR;
       }
     }

--- a/generic/casstcl_types.c
+++ b/generic/casstcl_types.c
@@ -662,15 +662,15 @@ int casstcl_cass_value_to_tcl_obj (casstcl_sessionClientData *ct, const CassValu
 	CassError cassError;
       Tcl_Obj *listObjv[3];
 
-	CassError = cass_value_get_duration (cassValue, &months, &days, &nanos);
+	cassError = cass_value_get_duration (cassValue, &months, &days, &nanos);
 
       if (cassError != CASS_OK) {
         return casstcl_cass_error_to_tcl (ct, cassError);
       }
 
       listObjv[0] = Tcl_NewIntObj(months);
-      listObjv[1] = Tcl_NewintObj(days);
-      *tclObjv[2] = Tcl_NewWideIntObj (nanos);
+      listObjv[1] = Tcl_NewIntObj(days);
+      listObjv[2] = Tcl_NewWideIntObj (nanos);
       *tclObj = Tcl_NewListObj(3, listObjv);
       return TCL_OK;
     }

--- a/generic/casstcl_types.c
+++ b/generic/casstcl_types.c
@@ -2079,7 +2079,7 @@ casstcl_GetDurationFromObj(
     switch (c) {
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
-	value = value * 10 + *string - '0';
+	value = value * 10 + c - '0';
 	break;
       }
       case 'y': {

--- a/generic/casstcl_types.h
+++ b/generic/casstcl_types.h
@@ -438,4 +438,29 @@ casstcl_GetInetFromObj(
     Tcl_Obj *objPtr,  /* The object from which to get an Inet. */
     CassInet *inetPtr);  /* Place to store resulting Inet. */
 
+/*
+ *----------------------------------------------------------------------
+ *
+ * casstcl_GetDurationFromObj --
+ *
+ *   Attempt to convert a string in one of the formats Cassandra expects
+ *      as a duration into months, days, and nanoseconds
+ *
+ * Results:
+ *   A standard Tcl result.
+ *
+ * Side Effects:
+ *
+ *   None.
+ *
+ *----------------------------------------------------------------------
+ */
+int
+casstcl_GetDurationFromObj(
+    Tcl_Interp *interp, /* Used for error reporting if not NULL. */
+    Tcl_Obj *objPtr,  /* The object from which to get an Inet. */
+    cass_int32_t *monthp, /* resulting months. */
+    cass_int32_t *dayp,   /* resulting days. */
+    cass_int64_t *nanop);  /* Resulting nanoseconds. */
+
 /* vim: set ts=4 sw=4 sts=4 noet : */

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -13,6 +13,8 @@
 set tcltestVersion [package require tcltest]
 namespace import -force tcltest::*
 
+# tcltest::configure -verbose {body pass skip error}
+
 tcltest::testsDirectory [file dir [info script]]
 tcltest::runAllTests
 

--- a/tests/cass.test
+++ b/tests/cass.test
@@ -624,6 +624,9 @@ if {[llength [info commands cass_test_get_dummy_value]] == 0} then {
           }
         }
       }
+      duration {
+	return [list 0 0 0]
+      }
       default {
         if {[regexp -nocase -- {^list\s*<.+>$} $type] || \
             [regexp -nocase -- {^map\s*<.+>$} $type] || \
@@ -729,7 +732,8 @@ if {![info exists cass_test_cql]} then {
       value20 timestamp,
       value21 timeuuid,
       value22 uuid,
-      value23 varchar
+      value23 varchar,
+      value24 duration
     );
   }
 

--- a/tests/cass.test
+++ b/tests/cass.test
@@ -760,6 +760,17 @@ if {![info exists cass_test_cql]} then {
     INSERT INTO $keyspace.main (key01) VALUES (?);
   }
 
+  set cass_test_cql(11) {
+    CREATE TABLE $keyspace.main (
+      key00 int PRIMARY KEY,
+      key01 duration
+    );
+  }
+
+  set cass_test_cql(12) {
+    INSERT INTO $keyspace.main (key00, key01) VALUES (?, ?);
+  }
+
   set cass_test_cql(drop) {
     DROP KEYSPACE IF EXISTS $keyspace;
   }
@@ -2359,6 +2370,58 @@ test cass-14.3 {automatic scaling of timestamp data type} -body {
 (4294967295LL) while converting 'timestamp' element while attempting to\
 bind field name of 'key01' of type 'timestamp' referencing table\
 '$keyspace.main'}]]
+
+###############################################################################
+
+test cass-14.4 {duration data type} -body {
+  list [catch {
+    set keyspace [cass_test_get_keyspace]
+    cass_test_connect cmd
+    cass_test_exec $cmd [cass_test_subst $cass_test_cql(0)]
+    cass_test_exec $cmd [cass_test_subst $cass_test_cql(11)]
+    $cmd reimport_column_type_map
+    set prepared [$cmd prepare #auto \
+        [appendArgs $keyspace .main] \
+        [cass_test_subst $cass_test_cql(12)]]
+    cass_test_exec $cmd -prepared $prepared [list key00 1 key01 {1 1 0}]
+    set result [list]
+    $cmd select [cass_test_subst $cass_test_cql(8)] row {
+      lappend result [lsortStride2 [array get row]]
+    }
+    set result
+  } errMsg] $errMsg
+} -cleanup {
+  cass_test_service_events svc
+  cass_test_cleanup_session cmd true true
+
+  unset -nocomplain keyspace svc row prepared cmd errMsg
+} -result {0 {{key00 1 key01 {1 1 0}}}}
+
+###############################################################################
+
+test cass-14.4 {automatic conversion of duration data type} -body {
+  list [catch {
+    set keyspace [cass_test_get_keyspace]
+    cass_test_connect cmd
+    cass_test_exec $cmd [cass_test_subst $cass_test_cql(0)]
+    cass_test_exec $cmd [cass_test_subst $cass_test_cql(11)]
+    $cmd reimport_column_type_map
+    set prepared [$cmd prepare #auto \
+        [appendArgs $keyspace .main] \
+        [cass_test_subst $cass_test_cql(12)]]
+    cass_test_exec $cmd -prepared $prepared [list key00 1 key01 1mo1d]
+    set result [list]
+    $cmd select [cass_test_subst $cass_test_cql(8)] row {
+      lappend result [lsortStride2 [array get row]]
+    }
+    set result
+  } errMsg] $errMsg
+} -cleanup {
+  cass_test_service_events svc
+  cass_test_cleanup_session cmd true true
+
+  unset -nocomplain keyspace svc row prepared cmd errMsg
+} -result {0 {{key00 1 key01 {1 1 0}}}}
 
 ###############################################################################
 

--- a/tests/cass.test
+++ b/tests/cass.test
@@ -683,11 +683,11 @@ if {![info exists cass_test_cql]} then {
   }
 
   set cass_test_cql(1) {
-    SELECT keyspace_name FROM system.schema_keyspaces;
+    SELECT keyspace_name FROM system_schema.keyspaces;
   }
 
   set cass_test_cql(2) {
-    SELECT keyspace_name FROM system.schema_keyspaces
+    SELECT keyspace_name FROM system_schema.keyspaces
     WHERE keyspace_name = '$keyspace';
   }
 
@@ -843,7 +843,7 @@ test cass-5.1 {connect (failure)} -body {
   cass_test_cleanup_session cmd
 
   unset -nocomplain svc cmd errMsg
-} -result {1 {cassandra error: No hosts available: No hosts available for the control connection}}
+} -result {1 {cassandra error: No hosts available: Underlying connection error: Connect error 'connection refused'}}
 
 ###############################################################################
 
@@ -2374,8 +2374,7 @@ test cass-15.1 {asynchronous connect (failure)} -body {
   cass_test_cleanup_session cmd
 
   unset -nocomplain result svc cmd errMsg
-} -result {1 {cassandra error: No hosts available: No hosts available for the\
-control connection}}
+} -result {1 {cassandra error: No hosts available: Underlying connection error: Connect error 'connection refused'}}
 
 ###############################################################################
 

--- a/update_ver.sh
+++ b/update_ver.sh
@@ -2,12 +2,12 @@
 
 # This script simplifies the process of incrementing all version numbers for a new release.
 
-NEWVER="1.5"
+# make distclean *before* updating the version to make sure all the old version built files are gone.
+make distclean
+
+NEWVER="2.14.0"
 
 perl -p -i -e "s/^(AC_INIT\\(\\[[a-z_]+\\],) \\[[0-9.]+\\]/\\1 \\[$NEWVER\\]/" configure.in
 
 perl -p -i -e "s/^(\*Version) [0-9.]+(\*)/\\1 $NEWVER\\2/" README.md
 
-autoreconf
-
-make distclean


### PR DESCRIPTION
Add duration type represented as a 3-element list {months days nanoseconds}. It also accepts but does not return the default duration string for cassandra. ISO format duration strings are not implemented.